### PR TITLE
ci(deps): refresh dependency graph under protected /ff flow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -25,6 +25,19 @@ on:
       - '**/pr-**.yml'
       - '**/release.yml'
       - '**dependabot.yml'
+  # `workflow_dispatch` + `schedule` are LOAD-BEARING, not conveniences. Every
+  # merge into the protected default branch lands via the `/ff` bot, whose push
+  # uses GITHUB_TOKEN — and GitHub deliberately does NOT fire push-triggered
+  # workflows on GITHUB_TOKEN pushes (recursion guard). So the `push:` trigger
+  # above never fires on a bot-merged default branch; without these two the
+  # submitted graph would silently rot (stale transitives → lingering/late
+  # Dependabot alerts). `workflow_dispatch` (user/PAT token → not suppressed)
+  # gives on-demand re-submission after a dep-changing merge or for recovery;
+  # `schedule` keeps freshness hands-off so it never depends on someone
+  # remembering to dispatch. The job `if:` (default-branch only) still gates both.
+  workflow_dispatch:
+  schedule:
+    - cron: '47 3 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,17 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   BouncyCastle; commons-io) because it isn't named `classpath`. If a NEW
   never-shipped coord alerts under `manifest=settings.gradle.kts`, the filter
   regressed — don't bump/dismiss the dep.
+- **`dependency-submission.yml` MUST keep its `workflow_dispatch` + `schedule`
+  triggers.** Default-branch merges land via the `/ff` bot, whose push uses
+  `GITHUB_TOKEN`; GitHub does NOT fire push-triggered workflows on GITHUB_TOKEN
+  pushes (recursion guard), so the `push:` trigger never runs on a bot-merged
+  `dev`. Without the other two triggers the submitted dependency graph silently
+  rots → stale transitives → lingering/late Dependabot alerts. After a
+  dep-changing merge, refresh now via `gh workflow run
+  dependency-submission.yml --ref dev` (dispatched on your own token, so not
+  suppressed); the weekly `schedule` is the hands-off backstop. build.yml needs
+  no equivalent — required status checks read the PR-run contexts already
+  attached to the merged SHA, so its suppressed dev-push run is redundant.
 - ⚠ **Hit something else surprising? Add it here and tell the user.**
 
 ## What's NOT in this repo


### PR DESCRIPTION
P3 protection routes every dev merge through the `/ff` bot, whose `GITHUB_TOKEN` push is loop-suppressed → `dependency-submission.yml` (`push`-only) never re-submits the graph → stale transitives + the 9 settings-classpath maven alerts cannot clear.

Adds `workflow_dispatch` (on-demand/recovery, not token-suppressed) + weekly `schedule` (hands-off freshness). `build.yml` needs no equivalent: required checks read the PR-run contexts on the merged SHA.

After merge: `gh workflow run dependency-submission.yml --ref dev` to re-submit with `^runtimeClasspath$` and clear the 9 maven alerts.