### PR TITLE
test: falsify CI lockfile guard (DO NOT MERGE)

### DIFF
--- a/checks/dual/kotlin-js-store/yarn.lock
+++ b/checks/dual/kotlin-js-store/yarn.lock
@@ -1,0 +1,6 @@
+# THIS FILE IS A DELIBERATE TEST FIXTURE for the CI lockfile guard.
+# A committed kotlin-js-store/yarn.lock is forbidden (see .gitignore).
+# yarn lockfile v1
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz"


### PR DESCRIPTION
Throwaway PR. Plants a committed `checks/dual/kotlin-js-store/yarn.lock` (force-added past .gitignore) to empirically falsify, on the protected `dev` branch:

- **(a) guard-fires-in-CI**: the `Forbid committed Kotlin/JS lockfiles` step in build.yml must fail `Build and check on {ubuntu,macos,windows}` (closes the previously locally-only-tested caveat).
- **(b) block-red**: the `dev` ruleset must BLOCK a `/ff` merge while a required check is red.

Closed + branch-deleted after verification. **dev untouched.**