### PR TITLE
test: docs-only merge-gate probe (DO NOT MERGE)

### DIFF
--- a/PROBE.md
+++ b/PROBE.md
@@ -1,0 +1,5 @@
+# Throwaway merge-gate probe
+
+Docs-only change to falsify whether `**.md` paths-ignore leaves the
+required `Build and check on *` contexts unreported (→ PR un-mergeable).
+Not meant to merge.


### PR DESCRIPTION
RED reproducer for the ruleset×paths-ignore interaction. Observing whether a docs-only PR leaves the required Build contexts unreported → BLOCKED. Closed without merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation file with additional notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->