### PR TITLE
fix(ci): build docs-only PRs so required contexts report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,24 @@ jobs:
             exit 1
           fi
 
+      - name: Forbid paths-ignore on the pull_request trigger
+        # Self-guard (ubuntu runners ship yq). The branch ruleset requires
+        # this workflow's `Build and check on *` matrix contexts; an
+        # `on:`-level path-skip emits NO check runs, so re-adding
+        # `paths-ignore` to `pull_request` would silently make every
+        # docs-only PR un-mergeable (the contexts never report) — see the
+        # `on:` block comment. This gate converts that regression into an
+        # immediate red on the next code PR, instead of a mystery BLOCKED
+        # docs PR. `.["on"]` quotes the key: YAML 1.1 reads bare `on` as a
+        # boolean. Keep `paths-ignore` on `push` only (not status-gated).
+        if: matrix.os == 'ubuntu'
+        shell: bash
+        run: |
+          if [ "$(yq '.["on"].pull_request | has("paths-ignore")' .github/workflows/build.yml)" = "true" ]; then
+            echo "::error file=.github/workflows/build.yml::paths-ignore on the pull_request trigger is forbidden: a path-skipped workflow emits no check runs, so the ruleset-required 'Build and check on *' contexts never report and docs-only PRs are BLOCKED from merge forever. Keep paths-ignore on push only."
+            exit 1
+          fi
+
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,17 @@ on:
   # therefore disabled builds for PRs *into* `dev` — our default branch
   # and the merge target of every feature PR — so red shipped unseen.
   # Removed deliberately; never re-add a base filter that hides `dev` PRs.
+  #
+  # NO `paths-ignore` here, deliberately: the branch ruleset requires the
+  # `Build and check on {ubuntu,macos,windows}` contexts to pass before
+  # merge. A path-skipped workflow emits NO check runs, so those required
+  # contexts would never report and EVERY docs-only PR would be permanently
+  # BLOCKED from merge (empirically reproduced on PR #48). Docs PRs therefore
+  # build in full and report a real pass; `concurrency` below cancels
+  # superseded runs so iteration doesn't pile up. The `push` trigger keeps
+  # its `paths-ignore` (post-merge pushes aren't status-gated), so the glob
+  # list lives in exactly one place.
   pull_request:
-    paths-ignore:
-      - '**.*ignore'
-      - '**.md'
-      - '**.txt'
-      - '**/pr-**.yml'
-      - '**/release.yml'
-      - '**dependabot.yml'
   # Build only integration-branch pushes. Feature and `dependabot/**`
   # branches are already covered by their PR run above; gating them here
   # too would double-run (push + PR). No `tags:` trigger: a `v*` tag is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,23 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   suppressed); the weekly `schedule` is the hands-off backstop. build.yml needs
   no equivalent — required status checks read the PR-run contexts already
   attached to the merged SHA, so its suppressed dev-push run is redundant.
+- **`dev`+`main` are protected by a branch ruleset (`protect-integration-
+  branches`), the recurrence-prevention from the CI-recovery work.** It has NO
+  in-repo file (GitHub-side config) — query it via `gh api repos/<owner>/<repo>/
+  rulesets` (don't hardcode its numeric id; that changes on recreate). Required
+  contexts are EXACTLY build.yml's matrix job names `Build and check on
+  {ubuntu,macos,windows}`, each pinned to `integration_id: 15368` (github-actions)
+  so a same-named context from another app can't satisfy the gate. It uses the
+  `non_fast_forward` rule (blocks force-push), NOT the `pull_request` rule — so
+  the `/ff` bot's legitimate ff-push of an already-green SHA still merges; that's
+  also why `bypass_actors` is empty (no bypass needed). CodeQL + Scorecard are
+  deliberately NOT required (advisory). **Corollary trap — never add
+  `paths-ignore` to build.yml's `pull_request` trigger:** an `on:`-level
+  path-skip emits no check runs, so the required contexts never report and every
+  docs-only PR is permanently BLOCKED from merge (reproduced on PR #48). Docs PRs
+  must build in full; the `push` trigger keeps `paths-ignore` (post-merge pushes
+  aren't gated). If you change a build.yml matrix job NAME, update the ruleset's
+  required contexts in lockstep or the gate silently stops matching.
 - ⚠ **Hit something else surprising? Add it here and tell the user.**
 
 ## What's NOT in this repo


### PR DESCRIPTION
## Defect (reproduced on #48)
A docs-only PR matches build.yml's `pull_request` `paths-ignore` (`**.md`), skipping the whole workflow. The ruleset requires `Build and check on {ubuntu,macos,windows}`; a path-skipped workflow emits **no** check runs, so those required contexts never report → `mergeable=MERGEABLE` but `mergeStateStatus=BLOCKED` **forever**. This bricks every CHANGELOG/README/AGENTS PR — a defect introduced by the new ruleset.

## Fix
Remove `paths-ignore` from `pull_request` only (keep it on `push`). Docs PRs build in full → contexts report a real pass → mergeable. De-duplicates the glob list (was identical in both triggers) to one place. No new action/job, no ruleset change.

## Verify (GREEN)
After this lands, the #48 docs-only probe must flip to mergeable (contexts report). Reasoning captured permanently in the build.yml comment + an AGENTS.md gotcha (defense against re-adding the filter).