### PR TITLE
ci(build): guard pull_request against any path filter (close paths: bypass)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,18 @@ on:
   # and the merge target of every feature PR — so red shipped unseen.
   # Removed deliberately; never re-add a base filter that hides `dev` PRs.
   #
-  # NO `paths-ignore` here, deliberately: the branch ruleset requires the
-  # `Build and check on {ubuntu,macos,windows}` contexts to pass before
-  # merge. A path-skipped workflow emits NO check runs, so those required
-  # contexts would never report and EVERY docs-only PR would be permanently
-  # BLOCKED from merge (empirically reproduced on PR #48). Docs PRs therefore
-  # build in full and report a real pass; `concurrency` below cancels
-  # superseded runs so iteration doesn't pile up. The `push` trigger keeps
-  # its `paths-ignore` (post-merge pushes aren't status-gated), so the glob
-  # list lives in exactly one place.
+  # NO path filter (`paths`/`paths-ignore`) here, deliberately: the branch
+  # ruleset requires the `Build and check on {ubuntu,macos,windows}`
+  # contexts to pass before merge. A path-skipped workflow emits NO check
+  # runs, so those required contexts would never report and EVERY docs-only
+  # PR would be permanently BLOCKED from merge (empirically reproduced on
+  # PR #48). Both keys skip identically — `paths-ignore` on PRs touching
+  # only ignored globs, `paths` on PRs touching none of the listed globs —
+  # so the invariant is "no file-path filter", enforced by the guard step
+  # below. Docs PRs therefore build in full and report a real pass;
+  # `concurrency` below cancels superseded runs so iteration doesn't pile
+  # up. The `push` trigger keeps its `paths-ignore` (post-merge pushes
+  # aren't status-gated), so the glob list lives in exactly one place.
   pull_request:
   # Build only integration-branch pushes. Feature and `dependabot/**`
   # branches are already covered by their PR run above; gating them here
@@ -143,21 +146,26 @@ jobs:
             exit 1
           fi
 
-      - name: Forbid paths-ignore on the pull_request trigger
+      - name: Forbid path filters on the pull_request trigger
         # Self-guard (ubuntu runners ship yq). The branch ruleset requires
         # this workflow's `Build and check on *` matrix contexts; an
-        # `on:`-level path-skip emits NO check runs, so re-adding
-        # `paths-ignore` to `pull_request` would silently make every
-        # docs-only PR un-mergeable (the contexts never report) — see the
-        # `on:` block comment. This gate converts that regression into an
-        # immediate red on the next code PR, instead of a mystery BLOCKED
-        # docs PR. `.["on"]` quotes the key: YAML 1.1 reads bare `on` as a
-        # boolean. Keep `paths-ignore` on `push` only (not status-gated).
+        # `on:`-level path filter emits NO check runs for a non-matching
+        # PR, so re-adding EITHER `paths-ignore` OR `paths` to
+        # `pull_request` would silently make every docs-only PR
+        # un-mergeable (the contexts never report) — see the `on:` block
+        # comment. Both keys cause the identical skip: `paths-ignore`
+        # drops PRs touching only ignored globs; `paths` drops PRs
+        # touching none of the listed globs — so the invariant is "no
+        # file-path filter at all", not just "no paths-ignore". This gate
+        # converts that regression into an immediate red on the next code
+        # PR, instead of a mystery BLOCKED docs PR. `.["on"]` quotes the
+        # key: YAML 1.1 reads bare `on` as a boolean. Path filtering stays
+        # on `push` only (post-merge pushes aren't status-gated).
         if: matrix.os == 'ubuntu'
         shell: bash
         run: |
-          if [ "$(yq '.["on"].pull_request | has("paths-ignore")' .github/workflows/build.yml)" = "true" ]; then
-            echo "::error file=.github/workflows/build.yml::paths-ignore on the pull_request trigger is forbidden: a path-skipped workflow emits no check runs, so the ruleset-required 'Build and check on *' contexts never report and docs-only PRs are BLOCKED from merge forever. Keep paths-ignore on push only."
+          if [ "$(yq '.["on"].pull_request | (has("paths-ignore") or has("paths"))' .github/workflows/build.yml)" = "true" ]; then
+            echo "::error file=.github/workflows/build.yml::A path filter (paths-ignore/paths) on the pull_request trigger is forbidden: a path-skipped workflow emits no check runs, so the ruleset-required 'Build and check on *' contexts never report and docs-only PRs are BLOCKED from merge forever. Keep path filtering on push only."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,13 +362,18 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   `non_fast_forward` rule (blocks force-push), NOT the `pull_request` rule — so
   the `/ff` bot's legitimate ff-push of an already-green SHA still merges; that's
   also why `bypass_actors` is empty (no bypass needed). CodeQL + Scorecard are
-  deliberately NOT required (advisory). **Corollary trap — never add
-  `paths-ignore` to build.yml's `pull_request` trigger:** an `on:`-level
-  path-skip emits no check runs, so the required contexts never report and every
-  docs-only PR is permanently BLOCKED from merge (reproduced on PR #48). Docs PRs
-  must build in full; the `push` trigger keeps `paths-ignore` (post-merge pushes
-  aren't gated). If you change a build.yml matrix job NAME, update the ruleset's
-  required contexts in lockstep or the gate silently stops matching.
+  deliberately NOT required (advisory). **Corollary trap — never add a
+  file-path filter (`paths-ignore` OR `paths`) to build.yml's `pull_request`
+  trigger:** an `on:`-level path filter emits no check runs for a non-matching
+  PR, so the required contexts never report and every docs-only PR is permanently
+  BLOCKED from merge (reproduced on PR #48). Both keys skip identically —
+  `paths-ignore` on PRs touching only ignored globs, `paths` on PRs touching none
+  of the listed globs — so the invariant is "no path filter on the required
+  trigger", machine-enforced by build.yml's "Forbid path filters on the
+  pull_request trigger" step (a `paths:`-only guard would miss the `paths` half).
+  Docs PRs must build in full; the `push` trigger keeps `paths-ignore` (post-merge
+  pushes aren't gated). If you change a build.yml matrix job NAME, update the
+  ruleset's required contexts in lockstep or the gate silently stops matching.
 - ⚠ **Hit something else surprising? Add it here and tell the user.**
 
 ## What's NOT in this repo


### PR DESCRIPTION
## Why
The docs-PR merge-gate guard (#49) only forbade `paths-ignore` on the `pull_request` trigger. **`paths:` (positive filter) causes the identical brick** — GitHub emits zero check runs for a non-matching PR, so the ruleset-required `Build and check on *` contexts never report → docs-only PRs BLOCKED forever. `paths:` is the more common 'only build on source changes' reach, so the narrow guard left the real bypass open.

## What
- Guard predicate: `has("paths-ignore")` → `has("paths-ignore") or has("paths")` — enforces the true invariant: **no file-path filter on the required trigger**.
- `on:` + guard comments and the AGENTS.md gotcha now state the invariant (both keys skip identically), not the original symptom.

## Falsification (local, on the edited file)
GREEN (no filter) = false; RED for `paths-ignore`, `paths`, and both = true; `push` keeps its `paths-ignore`; actionlint clean (pre-existing SC2086 only). CI execution semantics already proven by the sibling lockfile guard (#47).

CI/infra-only — no consumer diff.