### PR TITLE
ci: fix stale build badge + two latent CI bugs (IS_DEFAULT_BRANCH footgun, broken PR cache cleanup)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,10 +164,22 @@ jobs:
         if: matrix.os == 'ubuntu'
         shell: bash
         run: |
-          if [ "$(yq '.["on"].pull_request | (has("paths-ignore") or has("paths"))' .github/workflows/build.yml)" = "true" ]; then
-            echo "::error file=.github/workflows/build.yml::A path filter (paths-ignore/paths) on the pull_request trigger is forbidden: a path-skipped workflow emits no check runs, so the ruleset-required 'Build and check on *' contexts never report and docs-only PRs are BLOCKED from merge forever. Keep path filtering on push only."
-            exit 1
-          fi
+          set -euo pipefail
+          # Fail CLOSED. A fail-open guard on a merge-gate is worse than none —
+          # it reads as "verified" while verifying nothing. `set -e` makes a
+          # missing/erroring yq abort the step; the `*)` arm blocks any
+          # unexpected output (empty/null from a restructured trigger) instead
+          # of silently passing.
+          has_filter=$(yq '.["on"].pull_request | (has("paths-ignore") or has("paths"))' .github/workflows/build.yml)
+          case "$has_filter" in
+            false) ;;
+            true)
+              echo "::error file=.github/workflows/build.yml::A path filter (paths-ignore/paths) on the pull_request trigger is forbidden: a path-skipped workflow emits no check runs, so the ruleset-required 'Build and check on *' contexts never report and docs-only PRs are BLOCKED from merge forever. Keep path filtering on push only."
+              exit 1 ;;
+            *)
+              echo "::error file=.github/workflows/build.yml::path-filter guard could not evaluate the pull_request trigger (yq returned '$has_filter') — failing closed. Check the yq expression / build.yml structure."
+              exit 1 ;;
+          esac
 
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,8 @@ jobs:
           # build run effectively never happens. Gating writes to it would
           # leave the cache permanently cold. Instead each PR self-warms its
           # own cache; pr-clean-cache.yml reaps the `refs/pull/N/merge` entries
-          # when the PR closes, so writable PRs don't accumulate.
+          # when the PR closes (and GitHub's 7-day unused-cache eviction is the
+          # backstop if that ever fails), so writable PRs don't accumulate.
           cache-read-only: false
           # Dependency-graph submission moved to its own workflow
           # (dependency-submission.yml) so build.yml can run with

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,11 +251,10 @@ jobs:
         timeout-minutes: 10
         working-directory: checks/kgp-only
         # Embedded-only smoke: KGP `abiValidation { }` activated, no
-        # external BCV plugin. Validates the new dual-mode trigger
-        # (commit 21), the task-based detection shim (commit 20), and
-        # `DirConfig.TARGET_DIR` short-circuit (commit 23). Also runs
-        # `checkKotlinAbi` so KGP's KLIB ABI baseline is verified in
-        # the same matrix invocation.
+        # external BCV plugin. Validates the dual-mode trigger, the
+        # task-based detection shim, and the `DirConfig.TARGET_DIR`
+        # short-circuit. Also runs `checkKotlinAbi` so KGP's KLIB ABI
+        # baseline is verified in the same matrix invocation.
         run: ./gradlew check checkKotlinAbi --continue --stacktrace --scan
         env:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ env:
   # Dependency-graph filter regexes live in
   # dependency-submission.yml now (the inline graph-submit step here
   # was removed alongside the `contents: write` tightening).
-  IS_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   buildAndCheck:
@@ -199,7 +198,15 @@ jobs:
           cache-cleanup: on-success
           cache-disabled: ${{ matrix.os == 'windows' }} # super slow on Windows.
           cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
-          cache-read-only: ${{ !env.IS_DEFAULT_BRANCH }}
+          # Writable on every run, deliberately. The canonical "write only on
+          # the default branch" pattern assumes the default branch gets build
+          # runs — but bot-`/ff` merges push via GITHUB_TOKEN, which GitHub's
+          # recursion guard stops from triggering this workflow, so a `dev`
+          # build run effectively never happens. Gating writes to it would
+          # leave the cache permanently cold. Instead each PR self-warms its
+          # own cache; pr-clean-cache.yml reaps the `refs/pull/N/merge` entries
+          # when the PR closes, so writable PRs don't accumulate.
+          cache-read-only: false
           # Dependency-graph submission moved to its own workflow
           # (dependency-submission.yml) so build.yml can run with
           # `contents: read`. The split also decouples graph-submit
@@ -213,7 +220,7 @@ jobs:
         run: ./gradlew build assemble check --continue --stacktrace --scan
 
       - name: Upload sarif report (Detekt)
-        if: always() && (github.event_name == 'pull_request' || env.IS_DEFAULT_BRANCH)
+        if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         continue-on-error: true
         with:
@@ -221,7 +228,7 @@ jobs:
           category: detekt
 
       - name: Upload sarif report (Lint)
-        if: always() && (github.event_name == 'pull_request' || env.IS_DEFAULT_BRANCH)
+        if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         continue-on-error: true
         with:

--- a/.github/workflows/pr-clean-cache.yml
+++ b/.github/workflows/pr-clean-cache.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [ closed ]
 
-# Strictly scoped — this job only deletes its own cache keys via
-# `gh actions-cache delete`. No writes to PRs, issues, or contents.
+# Strictly scoped — this job only deletes the closed PR's own cache
+# entries via `gh cache delete`. No writes to PRs, issues, or contents.
 permissions:
   actions: write
   contents: read
@@ -20,34 +20,21 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
+          # Native `gh cache` uses only the api.github.com REST API.
           allowed-endpoints: >
             api.github.com:443
-            objects.githubusercontent.com:443
 
       - name: Clean up
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: |
-          # Binary gh extensions are pinned by release tag; commit
-          # pins are for script extensions cloned from source.
-          # Without `--pin`, every workflow invocation pulls the
-          # extension's latest release — a silent supply-chain
-          # surface. v1.0.4 (2024-04-09) is the latest tagged
-          # release and matches sibling fluxo-kmp-conf's pin.
-          gh extension install actions/gh-actions-cache \
-            --pin v1.0.4
-
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )
-
-          ## Setting this to not fail the workflow while deleting cache keys.
-          set +e
-          echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
-          do
-              gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
-              echo " - Deleted cache key: $cacheKey"
-          done
-          echo "Done"
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        # Native `gh cache` (built into the gh CLI) replaces the old
+        # `actions/gh-actions-cache` extension. The extension's binary
+        # asset is served from release-assets.githubusercontent.com,
+        # which the egress allow-list blocks → `gh extension install`
+        # failed → cleanup silently stopped reaping closed-PR caches.
+        # Native talks only to api.github.com and drops a third-party
+        # supply-chain dependency. `--succeed-on-no-caches` keeps PRs
+        # that never produced a cache from failing the step.
+        run: gh cache delete --all --ref "$REF" --repo "$REPO" --succeed-on-no-caches

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,6 +374,20 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   this — the failure is cosmetic AND a job rename also breaks the ruleset's
   required contexts (blocking merges loudly), so it can't slip by unnoticed.
   Tracks `dev` (integration line), not `main` (lags until the release PR).
+- **`${{ !env.X }}` / `env.X` in a boolean position is a constant, not a
+  condition.** GitHub coerces a non-empty string to boolean `true` — and an
+  `env:` value is ALWAYS a string, so the literal `"false"` is truthy. A guard
+  like `cache-read-only: ${{ !env.IS_DEFAULT_BRANCH }}` therefore pinned to a
+  constant `false` (every PR wrote a Gradle cache — `actions/caches` showed
+  42 `refs/pull/57/merge` entries vs 1 on `dev`), and
+  `if: … || env.IS_DEFAULT_BRANCH` was always-true. actionlint does NOT flag
+  this (valid GitHub syntax, just dead semantics). Use the boolean-producing
+  comparison directly (`github.ref == format('refs/heads/{0}', …)`) or
+  `env.X == 'true'`; never negate/branch on a bare string env. The fix removed
+  the variable entirely — a correct gate is one line away if genuinely needed
+  (YAGNI). NB: here the constant-`false` was benign by accident — under
+  bot-`/ff` the default-branch build run is suppressed, so PR-writable caches
+  are what we actually want; see the `cache-read-only` comment in build.yml.
 - **`dev`+`main` are protected by a branch ruleset
   (`protect-integration-branches`), the recurrence-prevention from the
   CI-recovery work.** It has NO in-repo file (GitHub-side config) — query it via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,9 +349,31 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   rots → stale transitives → lingering/late Dependabot alerts. After a
   dep-changing merge, refresh now via `gh workflow run
   dependency-submission.yml --ref dev` (dispatched on your own token, so not
-  suppressed); the weekly `schedule` is the hands-off backstop. build.yml needs
-  no equivalent — required status checks read the PR-run contexts already
-  attached to the merged SHA, so its suppressed dev-push run is redundant.
+  suppressed); the weekly `schedule` is the hands-off backstop (the graph
+  feeds Dependabot **security alerts**, so freshness matters even absent a
+  merge). build.yml needs no equivalent — required status checks read the
+  PR-run contexts already attached to the merged SHA, so its suppressed
+  dev-push run is redundant (and the README build badge reads those same
+  per-SHA contexts, NOT build.yml's run history — see the badge gotcha below).
+- **README build badge = shields.io check-runs badge, NOT the Actions workflow
+  badge.** The workflow badge (`build.yml/badge.svg`) shows the latest *run on
+  the branch*; under bot-`/ff` no `build.yml` run ever lands on protected `dev`
+  (GITHUB_TOKEN push suppression), so it stayed frozen on the pre-recovery RED
+  run while every PR was green. The shields badge reads dev HEAD's per-SHA
+  check status — the SAME
+  source the ruleset gates on, always fresh, zero compute:
+  `…/github/check-runs/<owner>/<repo>/dev?nameFilter=Build%20and%20check%20on%20ubuntu&label=Build`.
+  `nameFilter` is EXACT-match (no substring/regex) → pins ONE context: ubuntu is
+  the strictest cell (only it runs `check-dual`) and all three OS contexts are
+  ruleset-required on an immutable-between-merges `dev`, so ubuntu-green ⟺
+  all-green — a faithful proxy that EXCLUDES advisory CodeQL/Scorecard (no
+  false-red in the mode they're designed to tolerate). Couples to the exact job
+  name (same string as the ruleset's required contexts): a rename detaches the
+  badge — it renders grey "unknown status" (NOT red), so update the badge
+  `nameFilter` in lockstep when renaming a matrix job. No machine guard for
+  this — the failure is cosmetic AND a job rename also breaks the ruleset's
+  required contexts (blocking merges loudly), so it can't slip by unnoticed.
+  Tracks `dev` (integration line), not `main` (lags until the release PR).
 - **`dev`+`main` are protected by a branch ruleset (`protect-integration-
   branches`), the recurrence-prevention from the CI-recovery work.** It has NO
   in-repo file (GitHub-side config) — query it via `gh api repos/<owner>/<repo>/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,10 +374,11 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   this — the failure is cosmetic AND a job rename also breaks the ruleset's
   required contexts (blocking merges loudly), so it can't slip by unnoticed.
   Tracks `dev` (integration line), not `main` (lags until the release PR).
-- **`dev`+`main` are protected by a branch ruleset (`protect-integration-
-  branches`), the recurrence-prevention from the CI-recovery work.** It has NO
-  in-repo file (GitHub-side config) — query it via `gh api repos/<owner>/<repo>/
-  rulesets` (don't hardcode its numeric id; that changes on recreate). Required
+- **`dev`+`main` are protected by a branch ruleset
+  (`protect-integration-branches`), the recurrence-prevention from the
+  CI-recovery work.** It has NO in-repo file (GitHub-side config) — query it via
+  `gh api repos/<owner>/<repo>/rulesets` (don't hardcode its numeric id; that
+  changes on recreate). Required
   contexts are EXACTLY build.yml's matrix job names `Build and check on
   {ubuntu,macos,windows}`, each pinned to `integration_id: 15368` (github-actions)
   so a same-named context from another app can't satisfy the gate. It uses the
@@ -392,7 +393,7 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   `paths-ignore` on PRs touching only ignored globs, `paths` on PRs touching none
   of the listed globs — so the invariant is "no path filter on the required
   trigger", machine-enforced by build.yml's "Forbid path filters on the
-  pull_request trigger" step (a `paths:`-only guard would miss the `paths` half).
+  pull_request trigger" step (a `paths-ignore`-only guard would miss the `paths` half).
   Docs PRs must build in full; the `push` trigger keeps `paths-ignore` (post-merge
   pushes aren't gated). If you change a build.yml matrix job NAME, update the
   ruleset's required contexts in lockstep or the gate silently stops matching.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,8 +360,8 @@ matrix ceiling is the physical upstream ceiling, not an arbitrary pin.
   the branch*; under bot-`/ff` no `build.yml` run ever lands on protected `dev`
   (GITHUB_TOKEN push suppression), so it stayed frozen on the pre-recovery RED
   run while every PR was green. The shields badge reads dev HEAD's per-SHA
-  check status — the SAME
-  source the ruleset gates on, always fresh, zero compute:
+  check status — the SAME source the ruleset gates on, always fresh, zero
+  compute:
   `…/github/check-runs/<owner>/<repo>/dev?nameFilter=Build%20and%20check%20on%20ubuntu&label=Build`.
   `nameFilter` is EXACT-match (no substring/regex) → pins ONE context: ubuntu is
   the strictest cell (only it runs `check-dual`) and all three OS contexts are

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Gradle Plugin Portal][badge-plugin]][plugin]
 [![JitPack][badge-jitpack]][jitpack]
-[![Build](../../actions/workflows/build.yml/badge.svg)](../../actions/workflows/build.yml)
+[![Build](https://img.shields.io/github/check-runs/fluxo-kt/fluxo-bcv-js/dev?nameFilter=Build%20and%20check%20on%20ubuntu&label=Build)](../../actions/workflows/build.yml)
 [![Common Changelog](https://common-changelog.org/badge.svg)](CHANGELOG.md)
 
 [![KotlinX BCV Compatibility](http://img.shields.io/badge/KotlinX%20BCV-0.8%20--%200.18.1-7F52FF?logo=kotlin&logoWidth=10&logoColor=7F52FF&labelColor=2B2B2B)][bcv]


### PR DESCRIPTION
Build-badge fix plus the confirmed review-leftovers from merged #49/#56. Four granular commits:

### 1. `docs(readme)`: build badge reads dev HEAD check status (the actual fix)
Old GitHub Actions badge showed the latest *run on the branch*; bot-`/ff` + GITHUB_TOKEN push-suppression means no `build.yml` run lands on protected `dev`, so it froze stale-RED while every PR was green. Now a shields.io check-runs badge filtered to dev HEAD's `Build and check on ubuntu` context — same per-SHA source the ruleset gates on; always fresh, zero compute, excludes advisory CodeQL/Scorecard (no false-red). Renders `Build: passing`.

### 2. `docs(build)`: drop transient `(commit 21/20/23)` refs from a comment (hygiene)

### 3. `fix(ci)`: path-filter guard fails **closed**
It used `if [ "$(yq …)" = true ]` — a missing/erroring yq or empty output silently PASSED, reading as 'verified' while verifying nothing on a merge-gate. Now `set -euo pipefail` + a `case` whose `*)` arm blocks unexpected output. (Copilot review on #56.)

### 4. `docs(agents)`: fix two code-span line-wraps (GFM renders the newline as a token-corrupting space in `protect-integration-branches` / `gh api …/rulesets`) + a `paths:`-only→`paths-ignore`-only logic typo. (gemini/Copilot on #49/#56.)

Rejected (over-engineering): a CI guard asserting badge↔matrix-job-name consistency — the rename failure is cosmetic (grey 'unknown', not red) and a rename also breaks the ruleset contexts (blocks merges loudly). Doc note in AGENTS.md instead.